### PR TITLE
php7.4 compatibility improvement

### DIFF
--- a/src/PHPixie/CLI/Context/SAPI.php
+++ b/src/PHPixie/CLI/Context/SAPI.php
@@ -111,7 +111,7 @@ class SAPI implements \PHPixie\CLI\Context
         array_shift($parameters);
         foreach($parameters as $parameter) {
 
-            if($parameter{0} !== '-') {
+            if($parameter[0] !== '-') {
                 $arguments[]= $parameter;
                 continue;
             }


### PR DESCRIPTION
Array and string offset access syntax with curly braces is deprecated